### PR TITLE
Correct an oversight in the configuration of the test consumer

### DIFF
--- a/daemon/src/main/scala/me/frmr/kafka/detective/monitor/MonitorWorker.scala
+++ b/daemon/src/main/scala/me/frmr/kafka/detective/monitor/MonitorWorker.scala
@@ -186,7 +186,7 @@ class MonitorWorker(
 
     new CallbackKafkaConsumer[Array[Byte], Array[Byte]](
       monitor.testSubject.topic,
-      monitor.referenceSubject.onlyPartitions,
+      monitor.testSubject.onlyPartitions,
       properties,
       backpressureFn = Some(shouldTestConsumerBackpressure _)
     )


### PR DESCRIPTION
Previously, the test consumer incorrectly pulled its partition info from
the reference topic. This corrects that mistake.

closes #1 